### PR TITLE
Fix table not fetching more items when existing ones almost fit height

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matpl/table",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "",
   "repository": {
     "type": "git",

--- a/src/wawa-table.ts
+++ b/src/wawa-table.ts
@@ -115,7 +115,7 @@ export class WawaTable extends LitElement {
 
                 if(items.length > 0) {
                     let div: HTMLDivElement = this.renderRoot.querySelector("div") as HTMLDivElement;
-                    if(div && div.clientHeight !== 0 && div.scrollHeight <= div.clientHeight) {
+                    if(div && div.clientHeight !== 0 && div.scrollHeight <= div.clientHeight + this.rowHeight) {
                         this.fetch();
                     }
                 }


### PR DESCRIPTION
The scroll bar would not show, preventing loading with scrolling, but the table would not detect there's still space left.